### PR TITLE
Court status endpoints

### DIFF
--- a/apps/api/cmd/server/main.go
+++ b/apps/api/cmd/server/main.go
@@ -78,6 +78,11 @@ func main() {
 	courtRepo := repository.NewCourtRepository(queries)
 	courtService := service.NewCourtService(courtRepo)
 	courtHandler := handler.NewCourtHandler(courtService)
+
+	statusRepo := repository.NewStatusRepository(queries)
+	statusService := service.NewStatusService(statusRepo)
+	statusHandler := handler.NewStatusHandler(statusService)
+
 	healthHandler := handler.NewHealthHandler(pool)
 
 	r := chi.NewRouter()
@@ -90,6 +95,7 @@ func main() {
 
 	healthHandler.RegisterRoutes(r)
 	courtHandler.RegisterRoutes(r)
+	statusHandler.RegisterRoutes(r)
 
 	server := &http.Server{
 		Addr:         fmt.Sprintf(":%s", cfg.Server.Port),

--- a/apps/api/cmd/server/main.go
+++ b/apps/api/cmd/server/main.go
@@ -79,7 +79,7 @@ func main() {
 	courtRepo := repository.NewCourtRepository(queries)
 	statusRepo := repository.NewStatusRepository(queries)
 
-	// Create services (StatusService first since CourtService depends on it)
+	// Create services
 	statusService := service.NewStatusService(statusRepo)
 	courtService := service.NewCourtService(courtRepo, statusService)
 

--- a/apps/api/cmd/server/main.go
+++ b/apps/api/cmd/server/main.go
@@ -75,12 +75,16 @@ func main() {
 
 	queries := db.New(pool)
 
+	// Create repositories
 	courtRepo := repository.NewCourtRepository(queries)
-	courtService := service.NewCourtService(courtRepo)
-	courtHandler := handler.NewCourtHandler(courtService)
-
 	statusRepo := repository.NewStatusRepository(queries)
+
+	// Create services (StatusService first since CourtService depends on it)
 	statusService := service.NewStatusService(statusRepo)
+	courtService := service.NewCourtService(courtRepo, statusService)
+
+	// Create handlers
+	courtHandler := handler.NewCourtHandler(courtService)
 	statusHandler := handler.NewStatusHandler(statusService)
 
 	healthHandler := handler.NewHealthHandler(pool)

--- a/apps/api/internal/api/handler/status.go
+++ b/apps/api/internal/api/handler/status.go
@@ -1,0 +1,69 @@
+package handler
+
+import (
+	"net/http"
+	"strconv"
+
+	"paddletraffic/internal/api/response"
+	"paddletraffic/internal/service"
+
+	"github.com/go-chi/chi/v5"
+)
+
+type StatusHandler struct {
+	service *service.StatusService
+}
+
+func NewStatusHandler(service *service.StatusService) *StatusHandler {
+	return &StatusHandler{service: service}
+}
+
+func (h *StatusHandler) RegisterRoutes(r chi.Router) {
+	r.Route("/v1/status", func(r chi.Router) {
+		r.Get("/", h.GetStatusBatch)
+		r.Get("/{courtId}", h.GetStatusByCourtID)
+	})
+}
+
+func (h *StatusHandler) GetStatusByCourtID(w http.ResponseWriter, r *http.Request) {
+	courtIDStr := chi.URLParam(r, "courtId")
+	courtID, err := strconv.ParseInt(courtIDStr, 10, 64)
+	if err != nil {
+		response.BadRequest(w, "Invalid courtId parameter")
+		return
+	}
+
+	status, err := h.service.GetStatusByCourtID(r.Context(), courtID)
+	if err != nil {
+		response.InternalError(w, "Failed to fetch court status")
+		return
+	}
+
+	response.OK(w, status)
+}
+
+func (h *StatusHandler) GetStatusBatch(w http.ResponseWriter, r *http.Request) {
+	courtIDsParam := r.URL.Query()["courtIds"]
+	if len(courtIDsParam) == 0 {
+		response.BadRequest(w, "courtIds query parameter is required")
+		return
+	}
+
+	courtIDs := make([]int64, 0, len(courtIDsParam))
+	for _, idStr := range courtIDsParam {
+		id, err := strconv.ParseInt(idStr, 10, 64)
+		if err != nil {
+			response.BadRequest(w, "Invalid courtId in courtIds array")
+			return
+		}
+		courtIDs = append(courtIDs, id)
+	}
+
+	statuses, err := h.service.GetStatusBatch(r.Context(), courtIDs)
+	if err != nil {
+		response.InternalError(w, "Failed to fetch court statuses")
+		return
+	}
+
+	response.OK(w, statuses)
+}

--- a/apps/api/internal/database/generated/db/querier.go
+++ b/apps/api/internal/database/generated/db/querier.go
@@ -12,6 +12,10 @@ type Querier interface {
 	CountCourts(ctx context.Context) (int64, error)
 	CreateCourt(ctx context.Context, arg CreateCourtParams) (CreateCourtRow, error)
 	GetAllCourts(ctx context.Context, arg GetAllCourtsParams) ([]GetAllCourtsRow, error)
+	GetCourtStatus(ctx context.Context, courtID int64) (GetCourtStatusRow, error)
+	GetCourtStatusBatch(ctx context.Context, dollar_1 []int64) ([]GetCourtStatusBatchRow, error)
+	InsertCourtStatus(ctx context.Context, arg InsertCourtStatusParams) (InsertCourtStatusRow, error)
+	UpdateCourtStatus(ctx context.Context, arg UpdateCourtStatusParams) (UpdateCourtStatusRow, error)
 }
 
 var _ Querier = (*Queries)(nil)

--- a/apps/api/internal/database/queries/courts.sql
+++ b/apps/api/internal/database/queries/courts.sql
@@ -55,3 +55,32 @@ LIMIT $1 OFFSET $2;
 
 -- name: CountCourts :one
 SELECT COUNT(*) FROM court;
+
+-- name: GetCourtStatus :one
+SELECT
+  cs.court_id,
+  cs.courts_occupied,
+  cs.groups_waiting
+FROM court_status cs
+WHERE cs.court_id = $1;
+
+-- name: GetCourtStatusBatch :many
+SELECT
+  cs.court_id,
+  cs.courts_occupied,
+  cs.groups_waiting
+FROM court_status cs
+WHERE cs.court_id = ANY($1::bigint[]);
+
+-- name: InsertCourtStatus :one
+INSERT INTO court_status (court_id, courts_occupied, groups_waiting)
+VALUES ($1, $2, $3)
+RETURNING court_id, courts_occupied, groups_waiting, created_at, updated_at;
+
+-- name: UpdateCourtStatus :one
+UPDATE court_status
+SET
+  courts_occupied = $2,
+  groups_waiting = $3
+WHERE court_id = $1
+RETURNING court_id, courts_occupied, groups_waiting, created_at, updated_at;

--- a/apps/api/internal/dto/court.go
+++ b/apps/api/internal/dto/court.go
@@ -27,3 +27,10 @@ type CourtSummary struct {
 	CourtCount int32    `json:"courtCount"`
 	Location   Location `json:"location"`
 }
+
+type CourtStatus struct {
+	CourtID        int64   `json:"courtId"`
+	CourtsOccupied int32   `json:"courtsOccupied"`
+	GroupsWaiting  int32   `json:"groupsWaiting"`
+	LastReport     *string `json:"lastReport"` // TODO: Implement from reports table; ISO 8601 datetime
+}

--- a/apps/api/internal/repository/interfaces.go
+++ b/apps/api/internal/repository/interfaces.go
@@ -11,3 +11,10 @@ type CourtRepository interface {
 	Create(ctx context.Context, courtCreate dto.CourtCreate) (dto.CourtSummary, error)
 	GetAll(ctx context.Context, params dto.PaginationParams) (dto.Paginated[dto.CourtSummary], error)
 }
+
+type StatusRepository interface {
+	GetStatusByCourtID(ctx context.Context, courtID int64) (dto.CourtStatus, error)
+	GetStatusBatch(ctx context.Context, courtIDs []int64) ([]dto.CourtStatus, error)
+	InsertStatus(ctx context.Context, courtID int64, courtsOccupied int32, groupsWaiting int32) (dto.CourtStatus, error)
+	UpdateStatus(ctx context.Context, courtID int64, courtsOccupied int32, groupsWaiting int32) (dto.CourtStatus, error)
+}

--- a/apps/api/internal/repository/status.go
+++ b/apps/api/internal/repository/status.go
@@ -1,0 +1,86 @@
+package repository
+
+import (
+	"context"
+
+	"paddletraffic/internal/database/generated/db"
+	"paddletraffic/internal/dto"
+)
+
+type statusRepositoryImpl struct {
+	queries *db.Queries
+}
+
+func NewStatusRepository(queries *db.Queries) StatusRepository {
+	return &statusRepositoryImpl{queries: queries}
+}
+
+func (r *statusRepositoryImpl) GetStatusByCourtID(ctx context.Context, courtID int64) (dto.CourtStatus, error) {
+	row, err := r.queries.GetCourtStatus(ctx, courtID)
+	if err != nil {
+		return dto.CourtStatus{}, err
+	}
+
+	return dto.CourtStatus{
+		CourtID:        row.CourtID,
+		CourtsOccupied: row.CourtsOccupied,
+		GroupsWaiting:  row.GroupsWaiting,
+		LastReport:     nil, // TODO: Implement from reports table
+	}, nil
+}
+
+func (r *statusRepositoryImpl) GetStatusBatch(ctx context.Context, courtIDs []int64) ([]dto.CourtStatus, error) {
+	rows, err := r.queries.GetCourtStatusBatch(ctx, courtIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	// Build result array with only the statuses that exist
+	statuses := make([]dto.CourtStatus, 0, len(rows))
+	for _, row := range rows {
+		statuses = append(statuses, dto.CourtStatus{
+			CourtID:        row.CourtID,
+			CourtsOccupied: row.CourtsOccupied,
+			GroupsWaiting:  row.GroupsWaiting,
+			LastReport:     nil, // TODO: Implement from reports table
+		})
+	}
+
+	return statuses, nil
+}
+
+func (r *statusRepositoryImpl) InsertStatus(ctx context.Context, courtID int64, courtsOccupied int32, groupsWaiting int32) (dto.CourtStatus, error) {
+	row, err := r.queries.InsertCourtStatus(ctx, db.InsertCourtStatusParams{
+		CourtID:        courtID,
+		CourtsOccupied: courtsOccupied,
+		GroupsWaiting:  groupsWaiting,
+	})
+	if err != nil {
+		return dto.CourtStatus{}, err
+	}
+
+	return dto.CourtStatus{
+		CourtID:        row.CourtID,
+		CourtsOccupied: row.CourtsOccupied,
+		GroupsWaiting:  row.GroupsWaiting,
+		LastReport:     nil, // TODO: Implement from reports table
+	}, nil
+}
+
+func (r *statusRepositoryImpl) UpdateStatus(ctx context.Context, courtID int64, courtsOccupied int32, groupsWaiting int32) (dto.CourtStatus, error) {
+	row, err := r.queries.UpdateCourtStatus(ctx, db.UpdateCourtStatusParams{
+		CourtID:        courtID,
+		CourtsOccupied: courtsOccupied,
+		GroupsWaiting:  groupsWaiting,
+	})
+	if err != nil {
+		return dto.CourtStatus{}, err
+	}
+
+	return dto.CourtStatus{
+		CourtID:        row.CourtID,
+		CourtsOccupied: row.CourtsOccupied,
+		GroupsWaiting:  row.GroupsWaiting,
+		LastReport:     nil, // TODO: Implement from reports table
+	}, nil
+}

--- a/apps/api/internal/service/court.go
+++ b/apps/api/internal/service/court.go
@@ -8,15 +8,33 @@ import (
 )
 
 type CourtService struct {
-	repo repository.CourtRepository
+	repo          repository.CourtRepository
+	statusService *StatusService
 }
 
-func NewCourtService(repo repository.CourtRepository) *CourtService {
-	return &CourtService{repo: repo}
+func NewCourtService(repo repository.CourtRepository, statusService *StatusService) *CourtService {
+	return &CourtService{
+		repo:          repo,
+		statusService: statusService,
+	}
 }
 
 func (s *CourtService) Create(ctx context.Context, courtCreate dto.CourtCreate) (dto.CourtSummary, error) {
-	return s.repo.Create(ctx, courtCreate)
+	courtSummary, err := s.repo.Create(ctx, courtCreate)
+	if err != nil {
+		return dto.CourtSummary{}, err
+	}
+
+	// Create initial status with 0 values for the new court
+	_, err = s.statusService.InsertStatus(ctx, courtSummary.ID, 0, 0)
+	if err != nil {
+		// Log the error but don't fail the court creation
+		// The status can be created later
+		// TODO: Consider whether we want to rollback the court creation or handle this differently
+		return courtSummary, err
+	}
+
+	return courtSummary, nil
 }
 
 func (s *CourtService) GetAll(ctx context.Context, params dto.PaginationParams) (dto.Paginated[dto.CourtSummary], error) {

--- a/apps/api/internal/service/court.go
+++ b/apps/api/internal/service/court.go
@@ -28,8 +28,6 @@ func (s *CourtService) Create(ctx context.Context, courtCreate dto.CourtCreate) 
 	// Create initial status with 0 values for the new court
 	_, err = s.statusService.InsertStatus(ctx, courtSummary.ID, 0, 0)
 	if err != nil {
-		// Log the error but don't fail the court creation
-		// The status can be created later
 		// TODO: Consider whether we want to rollback the court creation or handle this differently
 		return courtSummary, err
 	}

--- a/apps/api/internal/service/status.go
+++ b/apps/api/internal/service/status.go
@@ -1,0 +1,32 @@
+package service
+
+import (
+	"context"
+
+	"paddletraffic/internal/dto"
+	"paddletraffic/internal/repository"
+)
+
+type StatusService struct {
+	repo repository.StatusRepository
+}
+
+func NewStatusService(repo repository.StatusRepository) *StatusService {
+	return &StatusService{repo: repo}
+}
+
+func (s *StatusService) GetStatusByCourtID(ctx context.Context, courtID int64) (dto.CourtStatus, error) {
+	return s.repo.GetStatusByCourtID(ctx, courtID)
+}
+
+func (s *StatusService) GetStatusBatch(ctx context.Context, courtIDs []int64) ([]dto.CourtStatus, error) {
+	return s.repo.GetStatusBatch(ctx, courtIDs)
+}
+
+func (s *StatusService) InsertStatus(ctx context.Context, courtID int64, courtsOccupied int32, groupsWaiting int32) (dto.CourtStatus, error) {
+	return s.repo.InsertStatus(ctx, courtID, courtsOccupied, groupsWaiting)
+}
+
+func (s *StatusService) UpdateStatus(ctx context.Context, courtID int64, courtsOccupied int32, groupsWaiting int32) (dto.CourtStatus, error) {
+	return s.repo.UpdateStatus(ctx, courtID, courtsOccupied, groupsWaiting)
+}


### PR DESCRIPTION
Adds id and bulk ids endpoints for `status` endpoints.

In terms of design decisions, when we create a court I also initialize the status for that court to `0` courts occupied and `0` groups waiting.

I also added a repository method for updating the status that we can use when we come up with our update scheme.

closes #15 

